### PR TITLE
Allow adjustment of indicator font size

### DIFF
--- a/star-rating.svelte
+++ b/star-rating.svelte
@@ -106,9 +106,6 @@
   .star-container {
     display: flex;
   }
-  .indicator {
-    font-size: 2.5rem;
-  }
   .star-container:not(:last-child) {
     margin-right: 5px;
   }
@@ -143,13 +140,13 @@
               id="stop4"
               offset="100%"
               stop-opacity="1"
-              :stop-color={style.styleEmptyStarColor} />
+              stop-color={style.styleEmptyStarColor} />
           </linearGradient>
         </defs>
       </svg>
     {/each}
     {#if isIndicatorActive}
-      <div class="indicator">{rating}</div>
+      <div class="indicator" style="font-size: {style.indicatorFontSize || '2.5rem'};">{rating}</div>
     {/if}
   </div>
 </div>


### PR DESCRIPTION
I've added the default value into where it is used, I'd probably recommend this approach for the other styles since right now you have to specify *all* of them if you want to change just one.

I've also removed a spurious colon on the final stop, as I think it was accidental?